### PR TITLE
Breaking/trn 515/replace deasync

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ const transform = (options = {}) => (source, filename) => {
 		noStyles
 	} = options;
 
-	console.log(preprocess);
 	// strip out <style> tags to prevent errors with node-sass.
 	const normalized = noStyles !== false ? source.replace(styleRegex, '') : source;
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const process = (options = {}) => (source, filename) => {
 
   // strip out <style> tags to prevent errors with node-sass.
   const normalized = noStyles !== false ? source.replace(styleRegex, '') : source;
-  
+
 	let preprocessed;
 
 	if (preprocess) {
@@ -16,9 +16,15 @@ const process = (options = {}) => (source, filename) => {
 			.preprocess(normalized, preprocess || {}, {
 				filename
 			})
-			.then((result) => (preprocessed = result.code));
+			.then((result) => (preprocessed = result.code))
+			.catch(err => {
+				preprocessed = true;
+				throw err;
+			});
 
-		deasync.loopWhile(() => !preprocessed);
+	    while (!preprocessed) {
+	        deasync.runLoopOnce();
+		}
 	} else {
 		preprocessed = normalized;
 	}

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ const styleRegex = /<style[^>]*>[\S\s]*?<\/style>/g;
 const process = (options = {}) => (source, filename) => {
 	const { preprocess, debug, compilerOptions, noStyles } = options;
 
-  // strip out <style> tags to prevent errors with node-sass.
-  const normalized = noStyles !== false ? source.replace(styleRegex, '') : source;
+	// strip out <style> tags to prevent errors with node-sass.
+	const normalized =
+		noStyles !== false ? source.replace(styleRegex, '') : source;
 
 	let preprocessed;
 
@@ -17,13 +18,13 @@ const process = (options = {}) => (source, filename) => {
 				filename
 			})
 			.then((result) => (preprocessed = result.code))
-			.catch(err => {
+			.catch((err) => {
 				preprocessed = true;
 				throw err;
 			});
 
-	    while (!preprocessed) {
-	        deasync.runLoopOnce();
+		while (!preprocessed) {
+			deasync.runLoopOnce();
 		}
 	} else {
 		preprocessed = normalized;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jest-transform-svelte",
+  "name": "@oat-sa/jest-transform-svelte",
   "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -22,6 +22,27 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz",
+      "integrity": "sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==",
+      "dev": true
+    },
+    "@types/pug": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.4.tgz",
+      "integrity": "sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=",
+      "dev": true
+    },
+    "@types/sass": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.16.0.tgz",
+      "integrity": "sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "acorn-jsx": {
@@ -83,14 +104,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -182,19 +195,16 @@
         }
       }
     },
-    "deasync": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
-      "integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
-      "requires": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^1.7.1"
-      }
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
       "dev": true
     },
     "doctrine": {
@@ -431,11 +441,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -657,6 +662,12 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -698,11 +709,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-addon-api": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
-      "integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -933,6 +939,15 @@
         }
       }
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -953,6 +968,18 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.1.0.tgz",
       "integrity": "sha512-b5TyzV7Dx1ijN4QPNarhKq5rX98QHDmi18nF0G8KV3d5KX3Jj98Yu4+tzM97ktnXcfoVJmvONvPaX1ZI0mr8Dw==",
       "dev": true
+    },
+    "svelte-preprocess": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-4.6.1.tgz",
+      "integrity": "sha512-s7KdhR2pOsffyOzZIMEb315f6pfgeDnOWN47m6YKFeSEx3NMf/79Znc3vuG/Ai79SL/vsi86WDrjFPLGRfDesg==",
+      "dev": true,
+      "requires": {
+        "@types/pug": "^2.0.4",
+        "@types/sass": "^1.16.0",
+        "detect-indent": "^6.0.0",
+        "strip-indent": "^3.0.0"
+      }
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
-	"name": "jest-transform-svelte",
+	"name": "@oat-sa/jest-transform-svelte",
 	"version": "2.1.1",
 	"description": "Jest Transformer for Svelte components",
 	"main": "index.js",
+	"files": [
+		"index.js",
+		"preprocess.js"
+	],
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
@@ -28,9 +32,7 @@
 	"peerDependencies": {
 		"svelte": ">= 3"
 	},
-	"dependencies": {
-		"deasync": "^0.1.19"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"eslint": "^6.3.0",
 		"eslint-config-prettier": "^6.1.0",

--- a/preprocess.js
+++ b/preprocess.js
@@ -1,0 +1,13 @@
+const svelte = require('svelte/compiler');
+const sveltePreprocess = require('svelte-preprocess');
+const { source, filename, config } = process.env;
+
+let preprocessConfig = {};
+try {
+	preprocessConfig = JSON.parse(config);
+} catch(err){
+}
+
+svelte.preprocess(source, preprocessConfig, { filename }).then((r) => {
+	process.stdout.write(r.code);
+});


### PR DESCRIPTION
jest transformers needs to run synchronously (because they're hooking node's `require`) but svelte compilation is an async process.
To replace deasync, I've use a trick to run async code in a subprocess and wait it's output using `execSync`. This trick seems to used by other jest transformers.

See https://github.com/rspieker/jest-transform-svelte/issues/18 and https://github.com/abbr/deasync/issues/134 

How to test: 
 - run with companion PRs